### PR TITLE
Fix incorrect tab mentioned for frontend app registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ By default, Chat Copilot runs locally without authentication, using a guest user
 
    3. Click _Add a permission_
 
-   4. Select the tab _My APIs_
+   4. Select the tab _APIs my organization uses_
 
    5. Choose the app registration representing the web api backend
 


### PR DESCRIPTION
### Motivation and Context
This fixes incorrect documentation when trying to setup the azure application permissions for the frontend.

### Description
When adding the api permissions for the first time to the frontend, the "My APIs" will actually be empty:
![image](https://github.com/Rainson12/chat-copilot/assets/13119203/24b6281d-cec3-4f46-91a3-9fb1359f0dad)
(you can ignore the "hidden" - thats another app we have developed)

Instead the previously created exposure of the backend can only be found in the "APIs my organization uses" tab:
![image](https://github.com/Rainson12/chat-copilot/assets/13119203/1f570210-c732-4a2e-825a-e2be1ec3f7fe)
